### PR TITLE
Change links containing `master` to `main`

### DIFF
--- a/about_compiler.Rmd
+++ b/about_compiler.Rmd
@@ -10,7 +10,7 @@ For novice R users or those wishing to use our [example data set](about_data.htm
 ## Locally
 More experienced R users can download the Course Compiler app and run it locally on their machine. To obtain the app:
 
-1) Go to the [Course Compiler](https://github.com/EDUCE-UBC/EDUCE-UBC.github.io/tree/master/shiny_apps) app folder in our public Github repo.
+1) Go to the [Course Compiler](https://github.com/EDUCE-UBC/EDUCE-UBC.github.io/tree/main/shiny_apps) app folder in our public Github repo.
 2) Copy the link and paste it at [Gitzip](https://kinolien.github.io/gitzip/) (Top right corner beside the key icon) to download.
 3) Open the app.R file in [RStudio](https://www.rstudio.com/products/rstudio/download/).
 4) Click the "Run App" button or type "shiny::runApp()" in the console to launch the app.

--- a/about_manipulator.Rmd
+++ b/about_manipulator.Rmd
@@ -19,14 +19,14 @@ Once you have finalized the methods you would like to use, the tool allows you t
 Due to server constraints, multiple imputation and variance stabilizing transformation are currently unavailable in the app. To run them on your own, checkout the R packages [`mice`](https://cran.r-project.org/web/packages/mice/index.html) or [`DESeq2`](https://bioconductor.org/packages/release/bioc/html/DESeq2.html), respectively.
 
 ## Online
-To use the Data Manipulator online, simply deploy the Shiny app from this site, upload your data file, and begin exploring your data! We have some [practice data sets](https://github.com/EDUCE-UBC/EDUCE-UBC.github.io/tree/master/sample_files) obtained from the EDUCE [example data](about_data.html).
+To use the Data Manipulator online, simply deploy the Shiny app from this site, upload your data file, and begin exploring your data! We have some [practice data sets](https://github.com/EDUCE-UBC/EDUCE-UBC.github.io/tree/main/sample_files) obtained from the EDUCE [example data](about_data.html).
 
 If you wish to use your own data, the file must be in **.txt format** with samples as rows and OTU/ASV counts as columns. 
 
 ## Locally
 More experienced R users can download the Data Manipulator app and run it locally on their machine. To obtain the app:
 
-1) Go to the [Data Manipulator](https://github.com/EDUCE-UBC/EDUCE-UBC.github.io/tree/master/shiny_apps) app folder in our public Github repo.
+1) Go to the [Data Manipulator](https://github.com/EDUCE-UBC/EDUCE-UBC.github.io/tree/main/shiny_apps) app folder in our public Github repo.
 2) Copy the link and paste it at [Gitzip](https://kinolien.github.io/gitzip/) (Top right corner beside the key icon) to download.
 3) Open the app.R file in [RStudio](https://www.rstudio.com/products/rstudio/download/).
 4) Click the "Run App" button or type "shiny::runApp()" in the console to launch the app.

--- a/intermediate_R_ws_setup.Rmd
+++ b/intermediate_R_ws_setup.Rmd
@@ -16,7 +16,7 @@ output: html_document
 - Click on the button below to download the data file we will use during the workshop and save it on your Desktop or another convenient location.
   
 ```{r echo = FALSE}
-data_file <- read.csv("https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/Saanich_Data_clean.csv")
+data_file <- read.csv("https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_intermediate_ws.csv")
 
 downloadthis::download_this(data_file,
     output_name = "data_intermediate_R",

--- a/r_and_rstudio_ws_setup.Rmd
+++ b/r_and_rstudio_ws_setup.Rmd
@@ -8,7 +8,7 @@ output: html_document
 - Download the data file we will use during the workshop by clicking on the following button and save it in your Desktop or another convenient location.
   
 ```{r echo = FALSE}
-data_file <- read.csv("https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/data.csv")
+data_file <- read.csv("https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_intro_ws.csv")
 
 downloadthis::download_this(data_file,
     output_name = "data",

--- a/reproducibility_ws_setup.Rmd
+++ b/reproducibility_ws_setup.Rmd
@@ -22,7 +22,7 @@ params:
 3. Download the data file we will use during the workshop by clicking on the following button and save it in your Desktop or another convenient location.
   
 ```{r echo = FALSE}
-data_file <- read.csv("https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/data.csv")
+data_file <- read.csv("https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_intro_ws.csv")
 
 downloadthis::download_this(data_file,
     output_name = "data",

--- a/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/05.Unix_manipulation_tutorial.Rmd
+++ b/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/05.Unix_manipulation_tutorial.Rmd
@@ -67,7 +67,7 @@ You can practice with any file on your computer. Here, we will download the data
 
 ```{r}
 write.csv(
-  read.csv("https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/Saanich_Data.csv"),
+  read.csv("https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_tidyverse_ws.csv"),
   "Saanich_Data.csv", row.names=FALSE)
 ```
 

--- a/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/07.BLAST_tutorial.Rmd
+++ b/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/07.BLAST_tutorial.Rmd
@@ -45,7 +45,7 @@ For more information on the databases available for BLAST, see their [download p
 ### Download data
 The sequence data that we will use in this tutorial are 16S amplicon profiles of microbial communities in Saanich Inlet in August 2012. More information on this system can be found [here](https://educe-ubc.github.io/about_data.html). Specifically, 16S amplicon sequences were processed using [mothur](https://www.mothur.org/wiki/Main_Page) to yield representative sequences of each 97% (approximately species-level) operational taxonomic unit (OTU). Details on the data preparation can be found [here](https://github.com/EDUCE-UBC/workshops_other/blob/master/compute_canada_R/data/mothur_pipeline.Rmd).
 
-1. Download the [representative data sequences](https://github.com/EDUCE-UBC/workshop_data/archive/master.zip) and unzip.
+1. Download the representative data sequences:
     - We will use both `Saanich_OTU_rep.fasta` and `Saanich_OTU_rep_subset.fasta`
     - For ease, you should place the database and sequence files in a single directory on your Desktop like below
     - You can accomplish all of this in your Terminal with the following code
@@ -57,8 +57,8 @@ mkdir Desktop/BLAST_data
 cd Desktop/BLAST_data
 
 #Download sequences
-curl -O https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/main/Saanich_OTU_rep_subset.fasta
-curl -O https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/main/Saanich_OTU_rep.fasta
+curl -O https://raw.githubusercontent.com/EDUCE-UBC/workshops_access/main/data/Saanich_OTU_rep_subset.fasta
+curl -O https://raw.githubusercontent.com/EDUCE-UBC/workshops_access/main/data/Saanich_OTU_rep.fasta
 
 #Download database
 curl -O ftp://ftp.ncbi.nlm.nih.gov/blast/db/16SMicrobial.tar.gz

--- a/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/07.BLAST_tutorial.Rmd
+++ b/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/07.BLAST_tutorial.Rmd
@@ -57,8 +57,8 @@ mkdir Desktop/BLAST_data
 cd Desktop/BLAST_data
 
 #Download sequences
-curl -O https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/Saanich_OTU_rep_subset.fasta
-curl -O https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/Saanich_OTU_rep.fasta
+curl -O https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/main/Saanich_OTU_rep_subset.fasta
+curl -O https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/main/Saanich_OTU_rep.fasta
 
 #Download database
 curl -O ftp://ftp.ncbi.nlm.nih.gov/blast/db/16SMicrobial.tar.gz

--- a/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/09.Git_tutorial.Rmd
+++ b/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/09.Git_tutorial.Rmd
@@ -115,7 +115,7 @@ Now that we've added a file, we can query if there are any differences between o
 git status
 ```
 ```
-On branch master
+On branch main
 
 No commits yet
 
@@ -145,7 +145,7 @@ Now we see that our README is tracked but not committed.
 git status
 ```
 ```
-On branch master
+On branch main
 
 No commits yet
 
@@ -171,7 +171,7 @@ Once you have a version you want to save for all time, you need to `commit` it f
 git commit -m "Initialize README"
 ```
 ```
-[master (root-commit) 1515b4a] Initialize README
+[main (root-commit) 1515b4a] Initialize README
  Committer: Kim Dill-McFarland <kim@email.com>
 Your name and email address were configured automatically based
 on your username and hostname. Please check that they are accurate.
@@ -198,7 +198,7 @@ Now, we see that our local directory, index, and repo are all identical.
 git status
 ```
 ```
-On branch master
+On branch main
 nothing to commit, working tree clean
 ```
 
@@ -290,7 +290,7 @@ git add .
 git commit -m "Add birthday and color"
 ```
 ```
-[master f1b97c7] Add birthday and color
+[main f1b97c7] Add birthday and color
  Committer: Kim Dill-McFarland <kim@email.com>
  1 file changed, 2 insertions(+)
 ```
@@ -301,7 +301,7 @@ We can see all past commits in this repo with
 git log
 ```
 ```
-commit f1b97c7b50090383b9c40af0335a25d4b3df7982 (HEAD -> master)
+commit f1b97c7b50090383b9c40af0335a25d4b3df7982 (HEAD -> main)
 Author: Kim Dill-McFarland <kim@email.com>
 Date:   Mon May 6 17:03:51 2019 -0700
 
@@ -340,9 +340,9 @@ index 0000000..10ddd6d
 ![](images/Git_branch.png)
 \ 
 
-One of the best ways to avoid the need to undo anything in Git is to use branches. These are copies of your repo that you can work on independently of the "master" without impacting the master but still version control changes as you go. You can then choose to merge the branch with the master if you want to keep those changes or abandon the branch and go back the to the master if you do not want to keep those changes.
+One of the best ways to avoid the need to undo anything in Git is to use branches. These are copies of your repo that you can work on independently of the "main" without impacting the main but still version control changes as you go. You can then choose to merge the branch with the main if you want to keep those changes or abandon the branch and go back the to the main if you do not want to keep those changes.
 
-You may have noticed that many of our previous Git outputs start with `On branch master`. This is because by default, we were working on the master branch of the project (the only branch up to this point).
+You may have noticed that many of our previous Git outputs start with `On branch main`. This is because by default, we were working on the main branch of the project (the only branch up to this point).
 
 Branches are particularly useful to:
 
@@ -357,12 +357,12 @@ To start a new branch, first make sure that everything is up-to-date with `git s
 git status
 ```
 ```
-On branch master
+On branch main
 nothing to commit, working tree clean
 ```
 
 ```{bash eval=FALSE}
-git checkout -b new_branch master
+git checkout -b new_branch main
 ```
 ```
 Switched to a new branch 'new_branch'
@@ -378,7 +378,7 @@ On branch new_branch
 nothing to commit, working tree clean
 ```
 
-Now, we can make changes in this branch without impacting the master branch. Go ahead and edit `README.md` by adding another piece of information. Then `add and commit` this change in your new_branch.
+Now, we can make changes in this branch without impacting the main branch. Go ahead and edit `README.md` by adding another piece of information. Then `add and commit` this change in your new_branch.
 
 ```{bash eval=FALSE}
 echo 'I like cats.' >> README.md
@@ -392,16 +392,16 @@ new_branch d566b29] Add cats
  1 file changed, 1 insertion(+)
 ```
 
-The two branches no longer match so we must merge them and decide which version(s) to keep. To do so, we must first move back into the master branch
+The two branches no longer match so we must merge them and decide which version(s) to keep. To do so, we must first move back into the main branch
 
 ```{bash eval=FALSE}
-git checkout master
+git checkout main
 ```
 ```
-Switched to branch 'master'
+Switched to branch 'main'
 ```
 
-Then merge the branches, which overwrites the older master branch with our new changes in the new_branch
+Then merge the branches, which overwrites the older main branch with our new changes in the new_branch
 
 ```{bash eval=FALSE}
 git merge new_branch
@@ -433,7 +433,7 @@ You resolve a conflicts by merging, opening the file(s) with conflict(s), editin
 For example, we can make a new_branch2
 
 ```{bash eval=FALSE}
-git checkout -b new_branch2 master
+git checkout -b new_branch2 main
 ```
 ```
 Switched to a new branch 'new_branch2'
@@ -452,13 +452,13 @@ git commit -m "Add dogs"
  1 file changed, 1 insertion(+)
 ```
 
-Also modify the README in our master branch.
+Also modify the README in our main branch.
 
 ```{bash eval=FALSE}
-git checkout master
+git checkout main
 ```
 ```
-Switched to branch 'master'
+Switched to branch 'main'
 ```
 
 ```{bash eval=FALSE}
@@ -467,12 +467,12 @@ git add .
 git commit -m "Add dogs again"
 ```
 ```
-[master c427c53] Add dogs again
+[main c427c53] Add dogs again
  Committer: Kim Dill-McFarland <kim@email.com>
  1 file changed, 1 insertion(+)
 ```
 
-And now the version in the master has non-mergable changes compared to the new_branch2 version *e.g.* I can't both like and not like dogs. Thus, when we try to merge these branches, there is a conflict.
+And now the version in the main has non-mergable changes compared to the new_branch2 version *e.g.* I can't both like and not like dogs. Thus, when we try to merge these branches, there is a conflict.
 
 ```{bash eval=FALSE}
 git merge new_branch2
@@ -487,7 +487,7 @@ If we open the README, Git has marked the conflict(s) like so
 
 ```
 <<<<<< HEAD
-master version
+main version
 =======
 branch version
 >>>>>> name_of_branch
@@ -532,7 +532,7 @@ git add .
 git commit -m "Resolve dog conflict"
 ```
 ```
-[master 9641b08] Resolve dog conflict
+[main 9641b08] Resolve dog conflict
  Committer: Kim Dill-McFarland <kim@email.com>
 ```
 
@@ -542,7 +542,7 @@ And we can see our entire history, including the branches, in the log.
 git log
 ```
 ```
-commit 9641b0806f28b00cce1a07af524b4a321eb957b0 (HEAD -> master)
+commit 9641b0806f28b00cce1a07af524b4a321eb957b0 (HEAD -> main)
 Merge: c427c53 27c250f
 Author: Kim Dill-McFarland <kim@email.com>
 Date:   Mon May 6 17:08:38 2019 -0700
@@ -588,7 +588,7 @@ Thus far, we have covered the main Git terms and functions that you will need to
 - **Repository**: the contents (directory/folder) of a project including all history and versions for all files in that project
 - **Commit**: a snapshot of the state of the repository at a given point in time including the author, time, and a comment
 - **Staging/Index**: files marked for inclusion in the next commit as whatever version that they were *at the time they were staged*, not necessarily the most up-to-date version on your computer
-- **Branch**: a named sequence of commits kept separate from the original "master" sequence
+- **Branch**: a named sequence of commits kept separate from the original "main" sequence
 - **Merge**: including changes from one branch into another
 - **Conflict**: parallel changes to the same section(s) of a file that can't be automatically merged
 
@@ -602,7 +602,7 @@ Thus far, we have covered the main Git terms and functions that you will need to
 * `show`: show a detail account of a previous commit
 * `checkout`: create and move between branches or the local, index, and repo
     - Not shown here but `checkout HEAD` can be used to move to a past commit and re-instate file versions from that commit
-* `merge`: combine changes from a branch into the master repo (may result in conflicts)
+* `merge`: combine changes from a branch into the main repo (may result in conflicts)
 
 To checkout more functionalities in Git, see a [list of all Git commands](https://git-scm.com/docs).
 

--- a/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/10.Git_practice.Rmd
+++ b/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/10.Git_practice.Rmd
@@ -31,7 +31,7 @@ These problems are designed to help you practice concepts and functions covered 
 
 2. Resolve a merge conflict
     - Create another text file in your repo from #1. Add some text to the file and add/commit it. Then, create a new branch, change the text in the file, and add/commit to the branch.
-    - Will you be able to merge this branch with the master repo? If so, how? If not, why not?
+    - Will you be able to merge this branch with the main repo? If so, how? If not, why not?
     - Try it and see! If there is a merge conflict, resolve it and add/commit your final file version. Check the log to see all the steps you've completed!
 
 ***

--- a/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/11.GitHub_tutorial.Rmd
+++ b/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/11.GitHub_tutorial.Rmd
@@ -97,10 +97,10 @@ git remote add origin https://github.com/kdillmcfarland/TestRepo.git
 ```
 
 ### Update an online repo from local (`git push`)
-If no errors occur, you can now upload your local repo (with the README file) to GitHub with `push`. The first time you push, you need to specify to GitHub that you are pushing to the master branch of the repo.
+If no errors occur, you can now upload your local repo (with the README file) to GitHub with `push`. The first time you push, you need to specify to GitHub that you are pushing to the main branch of the repo.
 
 ```{bash eval=FALSE}
-git push -u origin master
+git push -u origin main
 ```
 ```
 Enumerating objects: 3, done.
@@ -110,8 +110,8 @@ Compressing objects: 100% (2/2), done.
 Writing objects: 100% (3/3), 303 bytes | 303.00 KiB/s, done.
 Total 3 (delta 0), reused 0 (delta 0)
 To https://github.com/kdillmcfarland/TestRepo.git
-* [new branch]      master -> master
-Branch 'master' set up to track remote branch 'master' from 'origin'.
+* [new branch]      main -> main
+Branch 'main' set up to track remote branch 'main' from 'origin'.
 ```
 
 All subsequent push commands for this repo can simply be
@@ -143,7 +143,7 @@ Despite this change on GitHub, if you go to your terminal on your computer, you 
 git status
 ```
 ```
-On branch master
+On branch main
 nothing to commit, working tree clean
 ```
 
@@ -159,7 +159,7 @@ remote: Compressing objects: 100% (2/2), done.
 remote: Total 3 (delta 1), reused 0 (delta 0), pack-reused 0
 Unpacking objects: 100% (3/3), done.
 From https://github.com/kdillmcfarland/TestRepo
-  cdca881..b95f3a9  master     -> origin/master
+  cdca881..b95f3a9  main     -> origin/main
 ```
 
 Now, you can see that the branch on your computer is 1 commit behind the branch on GitHub.
@@ -168,8 +168,8 @@ Now, you can see that the branch on your computer is 1 commit behind the branch 
 git status
 ```
 ```
-On branch master
-Your branch is behind 'origin/master' by 1 commit, and can be fast-forwarded.
+On branch main
+Your branch is behind 'origin/main' by 1 commit, and can be fast-forwarded.
  (use "git pull" to update your local branch)
 
 nothing to commit, working tree clean
@@ -193,7 +193,7 @@ Everything is now up to date
 git status
 ```
 ```
-On branch master
+On branch main
 nothing to commit, working tree clean
 ```
 
@@ -203,7 +203,7 @@ And you can see both your local and GitHub histories associated with this one re
 git log
 ```
 ```
-commit b95f3a95ffbc8dae2e15608d064b552483c810af (HEAD -> master, origin/master)
+commit b95f3a95ffbc8dae2e15608d064b552483c810af (HEAD -> main, origin/main)
 Author: Kimberly Dill-McFarland <21342185+kdillmcfarland@users.noreply.github.com>
 Date:   Tue Apr 2 21:07:50 2019 -0700
 

--- a/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/11.GitHub_tutorial.Rmd
+++ b/shiny_apps/course_knitter/Rmd_input/2.Introduction_to_command_line/11.GitHub_tutorial.Rmd
@@ -230,10 +230,10 @@ git clone URL.of.the.repo
 For example, you could clone all of the data files used in EDUCE using
 
 ```{bash eval=FALSE}
-git clone https://github.com/EDUCE-UBC/workshop_data
+git clone https://github.com/EDUCE-UBC/workshops_access/
 ```
 ```
-Cloning into 'workshop_data'...
+Cloning into 'workshops_access'...
 remote: Enumerating objects: 32, done.
 remote: Counting objects: 100% (32/32), done.
 remote: Compressing objects: 100% (28/28), done.

--- a/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/04.Base_R_tutorial.R
+++ b/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/04.Base_R_tutorial.R
@@ -4,7 +4,7 @@
 ###############################################
 ### Download data
 write.csv(
-  read.csv("https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/data.csv"),
+  read.csv("https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_intro_ws.csv"),
   "data.csv", row.names=FALSE)
 
 ###############################################

--- a/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/04.Base_R_tutorial.Rmd
+++ b/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/04.Base_R_tutorial.Rmd
@@ -27,7 +27,7 @@ If you would like to follow along, open a new RStudio session and create a Proje
 
 ```{r}
 write.csv(
-  read.csv("https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/data.csv"),
+  read.csv("https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_intro_ws.csv"),
   "data.csv", row.names=FALSE)
 ```
 

--- a/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/05.Base_R_practice.Rmd
+++ b/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/05.Base_R_practice.Rmd
@@ -29,7 +29,7 @@ Open a new RStudio session and create a Project. Download the data file `data.cs
 
 ```{r}
 write.csv(
-  read.csv("https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/data.csv"),
+  read.csv("https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_intro_ws.csv"),
   "data.csv", row.names=FALSE)
 ```
 

--- a/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/06.Data_manipulation_tutorial.R
+++ b/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/06.Data_manipulation_tutorial.R
@@ -5,7 +5,7 @@
 ###############################################
 ### Download data
 write.csv(
-  read.csv("https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/Saanich_Data.csv"),
+  read.csv("https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_tidyverse_ws.csv"),
   "Saanich_Data.csv", row.names=FALSE)
 
 ###############################################
@@ -95,7 +95,7 @@ dat <-
   mutate(Depth_m=Depth*1000)
 
 dat <- 
-  read_csv("https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/Saanich_Data.csv") %>%
+  read_csv("https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_tidyverse_ws.csv") %>%
   filter(!is.na(WS_O2)) %>% 
   select(Cruise, Date, Depth, WS_O2, WS_NO3, WS_H2S) %>% 
   rename(O2_uM=WS_O2, NO3_uM=WS_NO3, H2S_uM=WS_H2S) %>% 

--- a/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/06.Data_manipulation_tutorial.Rmd
+++ b/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/06.Data_manipulation_tutorial.Rmd
@@ -27,7 +27,7 @@ If you would like to follow along, open a new RStudio session and create a Proje
 
 ```{r}
 write.csv(
-  read.csv("https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/Saanich_Data.csv"),
+  read.csv("https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_tidyverse_ws.csv""),
   "Saanich_Data.csv", row.names=FALSE)
 ```
 
@@ -307,7 +307,7 @@ We could even go as far back as the Setup instructions and link the reading of t
 
 ```{r}
 dat <- 
-  read_csv("https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/Saanich_Data.csv") %>%
+  read_csv("https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_tidyverse_ws.csv") %>%
   filter(!is.na(WS_O2)) %>% 
   select(Cruise, Date, Depth, WS_O2, WS_NO3, WS_H2S) %>% 
   rename(O2_uM=WS_O2, NO3_uM=WS_NO3, H2S_uM=WS_H2S) %>% 

--- a/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/07.Data_manipulation_practice.Rmd
+++ b/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/07.Data_manipulation_practice.Rmd
@@ -59,7 +59,7 @@ Load the pre-cleaned data from our GitHub.
 
 ```{r}
 dat <- read_csv(
-  "https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/Saanich_Data_clean.csv")
+  "https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_intermediate_ws.csv")
 ```
 
 If you would like to learn more about Saanich Inlet and these data, checkout [our description](https://educe-ubc.github.io/about_data.html).

--- a/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/08.Data_visualization_tutorial.R
+++ b/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/08.Data_visualization_tutorial.R
@@ -5,7 +5,7 @@
 ###############################################
 ### Load data
 dat <- read.csv(
-  "https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/Saanich_Data_clean.csv")
+  "https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_intermediate_ws.csv")
 
 ### Load packages
 ### R v3.4 or newer

--- a/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/08.Data_visualization_tutorial.Rmd
+++ b/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/08.Data_visualization_tutorial.Rmd
@@ -26,7 +26,7 @@ If you would like to follow along, open a new RStudio session and create a Proje
 
 ```{r}
 dat <- read.csv(
-  "https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/Saanich_Data_clean.csv")
+  "https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_intermediate_ws.csv")
 ```
 
 Not sure what a Project is? Be sure to include the "RStudio tutorial" in your materials!

--- a/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/09.Data_visualization_practice.Rmd
+++ b/shiny_apps/course_knitter/Rmd_input/3.Introduction_to_R/09.Data_visualization_practice.Rmd
@@ -57,7 +57,7 @@ Load the pre-cleaned data from our GitHub.
 
 ```{r}
 pdat <- read.csv(
-  "https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/Saanich_Data_clean.csv")
+  "https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_intermediate_ws.csv")
 ```
 
 If you would like to learn more about Saanich Inlet and these data, checkout [our description](https://educe-ubc.github.io/about_data.html) as well as how these data were cleaned in our 'Data manipulation in R tutorial'.

--- a/shiny_apps/course_knitter/app.R
+++ b/shiny_apps/course_knitter/app.R
@@ -88,7 +88,7 @@ ui <- fluidPage(
             
             # Link to GitHub for Rmds
             tags$i("Raw R Markdowns are available on our ",
-            tags$a(href = "https://github.com/EDUCE-UBC/EDUCE-UBC.github.io/tree/master/shiny_apps/course_knitter/Rmd_input", "GitHub"))
+            tags$a(href = "https://github.com/EDUCE-UBC/EDUCE-UBC.github.io/tree/main/shiny_apps/course_knitter/Rmd_input", "GitHub"))
           )
       )
   )

--- a/tidyverse_ws_setup.Rmd
+++ b/tidyverse_ws_setup.Rmd
@@ -9,7 +9,7 @@ output: html_document
 - Download the data file we will use during the workshop by clicking on the following button and save it in your Desktop or another convenient location.
   
 ```{r echo = FALSE}
-data_file <- read.csv("https://raw.githubusercontent.com/EDUCE-UBC/workshop_data/master/Saanich_Data.csv")
+data_file <- read.csv("https://raw.githubusercontent.com/EDUCE-UBC/educer/main/data-raw/data_tidyverse_ws.csv")
 
 downloadthis::download_this(data_file,
     output_name = "data",


### PR DESCRIPTION
Hi Stephan! If you are reading this before reading the pull request in `educer`, please read that one first.

- In `07.BLAST_tutorial.Rmd`, there is a link to a repo called `workshops_other`. As far as I can tell this link is broken and no such repo exists. I didn't change this link.
- There is a zip file called `master.zip` inside `workshop_data`, that is linked to in the `07.BLAST_tutorial.Rmd`. I didn't move this file to `educer`, as I'm not sure whether that is the appropriate course of action. **Update:** the zip file only contained the `fasta` files (see below) so it was unnecessary. I changed the tutorial slightly so that people access the `fasta` files directly.
- There are a lot of `fasta` files in `workshop_data` that are used frequently in `07.BLAST_tutorial.Rmd file`. I didn't move them to `educer` (but I did change the link from `master` to `main`). **Update:** The links now point to `workshops_access`.
- In the git tutorials -- `09.Git_tutorial.Rmd` and `11.GitHub_tutorial.Rmd` -- I changed every instance of `master` to `main` (not just as parts of links but as the new default for teaching purposes). However, just like in `workshops`, these markdown files have pictures with the word "master" in them. So the picture is not coherent with the text